### PR TITLE
 upgrade and lock mdbook version to 0.4.22

### DIFF
--- a/packages/mdbook-infisearch/Cargo.toml
+++ b/packages/mdbook-infisearch/Cargo.toml
@@ -15,7 +15,7 @@ include = ["/src", "mark.min.js", "default_infi_search.json"]
 [dependencies]
 anyhow = "1.0"
 clap = "2.0"
-mdbook = "0.4.21"
+mdbook = "=0.4.22"
 infisearch = { path = "../infisearch", version="=0.10.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Lock the mdbook version to avoid version conflicts caused by the high toml version of mdbook 0.4.23.